### PR TITLE
feature/switchaudiosource detection

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string></string>
+	<string>com.beet.alfred_audio_switcher</string>
 	<key>category</key>
 	<string>Tools</string>
 	<key>connections</key>

--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string>com.beet.alfred_audio_switcher</string>
+	<string></string>
 	<key>category</key>
 	<string>Tools</string>
 	<key>connections</key>
@@ -914,12 +914,6 @@ print json
 				<integer>102</integer>
 				<key>script</key>
 				<string>query=$1
-
-if [ "$1" = "Bose TV Speaker" ]; 
-then
-	/opt/homebrew/bin/bluetoothconnector -c 78-2b-64-61-cc-95
-fi
-
 
 $audioswitch_path -s "$query"</string>
 				<key>scriptargtype</key>

--- a/info.plist
+++ b/info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>bundleid</key>
 	<string>com.beet.alfred_audio_switcher</string>
+	<key>category</key>
+	<string>Tools</string>
 	<key>connections</key>
 	<dict>
 		<key>059C7DE3-D813-487B-9203-42E1B0683513</key>
@@ -120,11 +122,49 @@
 				<false/>
 			</dict>
 		</array>
+		<key>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>60AE39BC-F324-49E0-A554-2C945CFC8458</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>548FC2F7-5327-4242-BA1A-CAEBBEB41FF2</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
 				<string>1968F288-3B50-4AC0-937E-1D82912AB1B5</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>60AE39BC-F324-49E0-A554-2C945CFC8458</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>3F26E162-AE62-4CA1-8141-1CF497E4B925</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>E39327B0-7BD5-413C-AB58-8C271E056095</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -286,6 +326,19 @@
 				<false/>
 			</dict>
 		</array>
+		<key>D59239E5-888F-44C4-8C72-49FCF029D846</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>D6209BF9-6CC3-41A8-8479-11F28E98278B</key>
 		<array>
 			<dict>
@@ -349,6 +402,19 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>1495BA6A-8FB6-4DE4-81B5-3CFE151A840E</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>18DD4ECD-D3CC-4456-8B95-C6A6E045AC87</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -555,7 +621,9 @@
 				<key>script</key>
 				<string>require "json"
 
-devices = `/usr/local/bin/switchaudiosource -a`.split(/\n/).map {|device_name| { title: device_name, subtitle: device_name, arg: device_name, autocomplete: device_name, match: device_name }}
+audioswitch = ENV["audioswitch_path"]
+
+devices = `#{audioswitch} -a`.split(/\n/).map {|device_name| { title: device_name, subtitle: device_name, arg: device_name, autocomplete: device_name, match: device_name }}
 
 json = { items: devices }.to_json
 
@@ -847,7 +915,13 @@ print json
 				<key>script</key>
 				<string>query=$1
 
-/usr/local/bin/switchaudiosource -s "$query"</string>
+if [ "$1" = "Bose TV Speaker" ]; 
+then
+	/opt/homebrew/bin/bluetoothconnector -c 78-2b-64-61-cc-95
+fi
+
+
+$audioswitch_path -s "$query"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -933,11 +1007,14 @@ print json
 				<key>script</key>
 				<string>require "json"
 
-devices = `/usr/local/bin/switchaudiosource -a`.split(/\n/).map {|device_name| { title: device_name, subtitle: device_name, arg: device_name, autocomplete: device_name, match: device_name }}
+audioswitch = ENV["audioswitch_path"]
+devices = `#{audioswitch} -a`.split(/\n/).map {|device_name| { title: device_name, subtitle: device_name, arg: device_name, autocomplete: device_name, match: device_name }}
 
 json = { items: devices }.to_json
 
 print json
+
+
 </string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
@@ -958,6 +1035,157 @@ print json
 			<string>197D094B-47AC-495F-9397-41F710D42765</string>
 			<key>version</key>
 			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alignment</key>
+				<integer>0</integer>
+				<key>backgroundcolor</key>
+				<string></string>
+				<key>fadespeed</key>
+				<integer>0</integer>
+				<key>fillmode</key>
+				<integer>0</integer>
+				<key>font</key>
+				<string></string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>largetypetext</key>
+				<string>Path not found</string>
+				<key>textcolor</key>
+				<string></string>
+				<key>wrapat</key>
+				<integer>50</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.largetype</string>
+			<key>uid</key>
+			<string>3F26E162-AE62-4CA1-8141-1CF497E4B925</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string>{var:audioswitch_path}</string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>0</integer>
+						<key>matchstring</key>
+						<string>nf</string>
+						<key>outputlabel</key>
+						<string>nf</string>
+						<key>uid</key>
+						<string>E39327B0-7BD5-413C-AB58-8C271E056095</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string></string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>60AE39BC-F324-49E0-A554-2C945CFC8458</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>query=$1
+
+if [ "$query" ]; then
+	SWITCHPATH="$1"
+elif [ -f /usr/lib/switchaudiosource ]; then
+    SWITCHPATH="/usr/lib/switchaudiosource"
+elif [ -f /opt/homebrew/bin/switchaudiosource ]; then
+	SWITCHPATH="/opt/homebrew/bin/switchaudiosource"
+else
+	SWITCHPATH"nf"
+fi
+
+/usr/libexec/PlistBuddy -c "Set :variables:audioswitch_path \"$SWITCHPATH\"" info.plist</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>keyword</key>
+				<string>asc</string>
+				<key>subtext</key>
+				<string>If you installed the binary in a custom path, pass it as argument.</string>
+				<key>text</key>
+				<string>Configure autoswitch path</string>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>D59239E5-888F-44C4-8C72-49FCF029D846</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>soundname</key>
+				<string>Funk</string>
+				<key>systemsound</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.playsound</string>
+			<key>uid</key>
+			<string>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>lastpathcomponent</key>
+				<false/>
+				<key>onlyshowifquerypopulated</key>
+				<false/>
+				<key>removeextension</key>
+				<false/>
+				<key>text</key>
+				<string>Configuration completed</string>
+				<key>title</key>
+				<string>Audio Switcher</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.notification</string>
+			<key>uid</key>
+			<string>18DD4ECD-D3CC-4456-8B95-C6A6E045AC87</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 	</array>
 	<key>readme</key>
@@ -985,7 +1213,14 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>xpos</key>
 			<integer>1465</integer>
 			<key>ypos</key>
-			<integer>295</integer>
+			<integer>290</integer>
+		</dict>
+		<key>18DD4ECD-D3CC-4456-8B95-C6A6E045AC87</key>
+		<dict>
+			<key>xpos</key>
+			<integer>815</integer>
+			<key>ypos</key>
+			<integer>610</integer>
 		</dict>
 		<key>1968F288-3B50-4AC0-937E-1D82912AB1B5</key>
 		<dict>
@@ -1015,6 +1250,13 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>ypos</key>
 			<integer>235</integer>
 		</dict>
+		<key>3F26E162-AE62-4CA1-8141-1CF497E4B925</key>
+		<dict>
+			<key>xpos</key>
+			<integer>630</integer>
+			<key>ypos</key>
+			<integer>480</integer>
+		</dict>
 		<key>49778D70-5A39-40D0-B412-3AEEFC0FB088</key>
 		<dict>
 			<key>xpos</key>
@@ -1022,12 +1264,26 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>ypos</key>
 			<integer>55</integer>
 		</dict>
+		<key>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</key>
+		<dict>
+			<key>xpos</key>
+			<integer>265</integer>
+			<key>ypos</key>
+			<integer>550</integer>
+		</dict>
 		<key>548FC2F7-5327-4242-BA1A-CAEBBEB41FF2</key>
 		<dict>
 			<key>xpos</key>
 			<integer>905</integer>
 			<key>ypos</key>
 			<integer>115</integer>
+		</dict>
+		<key>60AE39BC-F324-49E0-A554-2C945CFC8458</key>
+		<dict>
+			<key>xpos</key>
+			<integer>475</integer>
+			<key>ypos</key>
+			<integer>530</integer>
 		</dict>
 		<key>620BA959-FAC3-4CC8-A160-AA818683968E</key>
 		<dict>
@@ -1101,6 +1357,13 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>ypos</key>
 			<integer>160</integer>
 		</dict>
+		<key>D59239E5-888F-44C4-8C72-49FCF029D846</key>
+		<dict>
+			<key>xpos</key>
+			<integer>30</integer>
+			<key>ypos</key>
+			<integer>550</integer>
+		</dict>
 		<key>D6209BF9-6CC3-41A8-8479-11F28E98278B</key>
 		<dict>
 			<key>xpos</key>
@@ -1122,9 +1385,18 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>ypos</key>
 			<integer>150</integer>
 		</dict>
+		<key>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</key>
+		<dict>
+			<key>xpos</key>
+			<integer>635</integer>
+			<key>ypos</key>
+			<integer>610</integer>
+		</dict>
 	</dict>
 	<key>variables</key>
 	<dict>
+		<key>audioswitch_path</key>
+		<string></string>
 		<key>external_device</key>
 		<string></string>
 		<key>headphones_device</key>
@@ -1134,12 +1406,13 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 	</dict>
 	<key>variablesdontexport</key>
 	<array>
+		<string>audioswitch_path</string>
 		<string>headphones_device</string>
-		<string>speakers_device</string>
 		<string>external_device</string>
+		<string>speakers_device</string>
 	</array>
 	<key>version</key>
-	<string>0.3.1</string>
+	<string>0.4.1</string>
 	<key>webaddress</key>
 	<string>Credit to https://agileadam.com/2020/05/switch-audio-input-output-device-using-alfred/</string>
 </dict>

--- a/info.plist
+++ b/info.plist
@@ -122,19 +122,6 @@
 				<false/>
 			</dict>
 		</array>
-		<key>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</key>
-		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>60AE39BC-F324-49E0-A554-2C945CFC8458</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-		</array>
 		<key>548FC2F7-5327-4242-BA1A-CAEBBEB41FF2</key>
 		<array>
 			<dict>
@@ -148,11 +135,11 @@
 				<false/>
 			</dict>
 		</array>
-		<key>60AE39BC-F324-49E0-A554-2C945CFC8458</key>
+		<key>6BAA32B6-8AB0-4144-85F2-24D886B477D8</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>3F26E162-AE62-4CA1-8141-1CF497E4B925</string>
+				<string>4FE1F8FB-702B-4376-97D0-5A156EC1395E</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -164,7 +151,29 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</string>
+				<string>8DD2D80C-83E0-48CC-AAB1-50C062CAEAEE</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>8DD2D80C-83E0-48CC-AAB1-50C062CAEAEE</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>E39327B0-7BD5-413C-AB58-8C271E056095</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>73E94FD2-7DA5-4AFA-9246-144509D75D0A</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -177,7 +186,7 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>DC5AEE40-4C20-47A1-9B39-972783E5FDE4</string>
+				<string>D5E09E98-C428-4634-AC59-E74EDF974AD0</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -252,7 +261,20 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>DC5AEE40-4C20-47A1-9B39-972783E5FDE4</string>
+				<string>D5E09E98-C428-4634-AC59-E74EDF974AD0</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>C53A449E-1DA9-4409-80E7-5B0DF8412174</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>6BAA32B6-8AB0-4144-85F2-24D886B477D8</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -317,7 +339,7 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>DC5AEE40-4C20-47A1-9B39-972783E5FDE4</string>
+				<string>D5E09E98-C428-4634-AC59-E74EDF974AD0</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -326,11 +348,23 @@
 				<false/>
 			</dict>
 		</array>
-		<key>D59239E5-888F-44C4-8C72-49FCF029D846</key>
+		<key>D5E09E98-C428-4634-AC59-E74EDF974AD0</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</string>
+				<string>DC5AEE40-4C20-47A1-9B39-972783E5FDE4</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>F4EB87FF-82A8-442F-A2D6-CD7371BE830C</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>C53A449E-1DA9-4409-80E7-5B0DF8412174</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -410,19 +444,6 @@
 				<false/>
 			</dict>
 		</array>
-		<key>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</key>
-		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>18DD4ECD-D3CC-4456-8B95-C6A6E045AC87</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-		</array>
 	</dict>
 	<key>createdby</key>
 	<string>Mark Beattie</string>
@@ -434,47 +455,6 @@
 	<string>Audio Switcher</string>
 	<key>objects</key>
 	<array>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argumenttype</key>
-				<integer>2</integer>
-				<key>keyword</key>
-				<string>ash</string>
-				<key>subtext</key>
-				<string></string>
-				<key>text</key>
-				<string>Switch audio output to headphones</string>
-				<key>withspace</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
-			<key>uid</key>
-			<string>AE8B0F21-A389-4316-8E23-D5647A36D2B2</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argument</key>
-				<string></string>
-				<key>passthroughargument</key>
-				<false/>
-				<key>variables</key>
-				<dict>
-					<key>selected_device</key>
-					<string>headphones_device</string>
-				</dict>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.argument</string>
-			<key>uid</key>
-			<string>49778D70-5A39-40D0-B412-3AEEFC0FB088</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
@@ -498,17 +478,21 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>argument</key>
-				<string>{var:headphones_device}</string>
-				<key>passthroughargument</key>
+				<key>argumenttype</key>
+				<integer>2</integer>
+				<key>keyword</key>
+				<string>ash</string>
+				<key>subtext</key>
+				<string></string>
+				<key>text</key>
+				<string>Switch audio output to headphones</string>
+				<key>withspace</key>
 				<false/>
-				<key>variables</key>
-				<dict/>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.utility.argument</string>
+			<string>alfred.workflow.input.keyword</string>
 			<key>uid</key>
-			<string>BEB65075-1263-4D24-808C-B6B29E5C3C15</string>
+			<string>AE8B0F21-A389-4316-8E23-D5647A36D2B2</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -590,6 +574,26 @@
 			<string>alfred.workflow.utility.conditional</string>
 			<key>uid</key>
 			<string>1968F288-3B50-4AC0-937E-1D82912AB1B5</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string></string>
+				<key>passthroughargument</key>
+				<false/>
+				<key>variables</key>
+				<dict>
+					<key>selected_device</key>
+					<string>headphones_device</string>
+				</dict>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>49778D70-5A39-40D0-B412-3AEEFC0FB088</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -693,6 +697,73 @@ print json
 				<array>
 					<dict>
 						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>0</integer>
+						<key>matchstring</key>
+						<string></string>
+						<key>outputlabel</key>
+						<string>Audio device blank</string>
+						<key>uid</key>
+						<string>0BCCAE4F-73D3-45F2-8954-5B9C1BD40AD1</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>else</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>DC5AEE40-4C20-47A1-9B39-972783E5FDE4</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string>{var:headphones_device}</string>
+				<key>passthroughargument</key>
+				<false/>
+				<key>variables</key>
+				<dict/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>BEB65075-1263-4D24-808C-B6B29E5C3C15</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string></string>
+				<key>passthroughargument</key>
+				<true/>
+				<key>variables</key>
+				<dict>
+					<key>external_device</key>
+					<string>{query}</string>
+				</dict>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>D948D25C-D746-40A9-9BB0-DFF412AE65F1</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
 						<string>{var:selected_device}</string>
 						<key>matchcasesensitive</key>
 						<false/>
@@ -772,26 +843,26 @@ print json
 				<array>
 					<dict>
 						<key>inputstring</key>
-						<string></string>
+						<string>{var:audioswitch_path}</string>
 						<key>matchcasesensitive</key>
 						<false/>
 						<key>matchmode</key>
-						<integer>0</integer>
+						<integer>1</integer>
 						<key>matchstring</key>
 						<string></string>
 						<key>outputlabel</key>
-						<string>Audio device blank</string>
+						<string>audioswitch configured</string>
 						<key>uid</key>
-						<string>0BCCAE4F-73D3-45F2-8954-5B9C1BD40AD1</string>
+						<string>F4EB87FF-82A8-442F-A2D6-CD7371BE830C</string>
 					</dict>
 				</array>
 				<key>elselabel</key>
-				<string>else</string>
+				<string>audioswitch not found</string>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.utility.conditional</string>
 			<key>uid</key>
-			<string>DC5AEE40-4C20-47A1-9B39-972783E5FDE4</string>
+			<string>D5E09E98-C428-4634-AC59-E74EDF974AD0</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -809,6 +880,21 @@ print json
 			<string>alfred.workflow.utility.argument</string>
 			<key>uid</key>
 			<string>D427E874-D8B4-470E-8C2F-D6EFC48348BB</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>soundname</key>
+				<string>Funk</string>
+				<key>systemsound</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.playsound</string>
+			<key>uid</key>
+			<string>33383FFA-0734-4D1B-8544-AF2BE673B5E8</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -836,26 +922,6 @@ print json
 			<key>config</key>
 			<dict>
 				<key>argument</key>
-				<string></string>
-				<key>passthroughargument</key>
-				<true/>
-				<key>variables</key>
-				<dict>
-					<key>external_device</key>
-					<string>{query}</string>
-				</dict>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.argument</string>
-			<key>uid</key>
-			<string>D948D25C-D746-40A9-9BB0-DFF412AE65F1</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argument</key>
 				<string>{var:external_device}</string>
 				<key>passthroughargument</key>
 				<false/>
@@ -872,36 +938,21 @@ print json
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>soundname</key>
-				<string>Funk</string>
-				<key>systemsound</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.output.playsound</string>
-			<key>uid</key>
-			<string>33383FFA-0734-4D1B-8544-AF2BE673B5E8</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argumenttype</key>
-				<integer>2</integer>
-				<key>keyword</key>
-				<string>asx</string>
-				<key>subtext</key>
-				<string>WARNING: loud, no system volume contorl</string>
-				<key>text</key>
-				<string>Switch audio output to external device</string>
-				<key>withspace</key>
+				<key>lastpathcomponent</key>
 				<false/>
+				<key>onlyshowifquerypopulated</key>
+				<false/>
+				<key>removeextension</key>
+				<false/>
+				<key>text</key>
+				<string>Please select your audio device again</string>
+				<key>title</key>
+				<string>Configured audioswitch</string>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
+			<string>alfred.workflow.output.notification</string>
 			<key>uid</key>
-			<string>728B5A4C-49FB-4657-8E62-EF5B81E0ACCA</string>
+			<string>4FE1F8FB-702B-4376-97D0-5A156EC1395E</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -929,6 +980,108 @@ $audioswitch_path -s "$query"</string>
 			<string>1495BA6A-8FB6-4DE4-81B5-3CFE151A840E</string>
 			<key>version</key>
 			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>query=$1
+
+# `which switchaudiosource` can't find binaries in /usr/loca/bin/
+if [ -f /usr/lib/switchaudiosource ]; then
+    SWITCHPATH="/usr/lib/switchaudiosource"
+elif [ -f /opt/homebrew/bin/switchaudiosource ]; then
+	SWITCHPATH="/opt/homebrew/bin/switchaudiosource"
+elif [ -f /usr/local/bin/switchaudiosource ]; then
+	SWITCHPATH="/usr/local/bin/switchaudiosource"
+else
+	SWITCHPATH="nf"
+fi
+
+/usr/libexec/PlistBuddy -c "Set :variables:audioswitch_path \"$SWITCHPATH\"" info.plist</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>C53A449E-1DA9-4409-80E7-5B0DF8412174</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string>{var:audioswitch_path}</string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>1</integer>
+						<key>matchstring</key>
+						<string>nf</string>
+						<key>outputlabel</key>
+						<string>audioswitch found</string>
+						<key>uid</key>
+						<string>E39327B0-7BD5-413C-AB58-8C271E056095</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>audioswitch not found</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>6BAA32B6-8AB0-4144-85F2-24D886B477D8</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>2</integer>
+				<key>keyword</key>
+				<string>asx</string>
+				<key>subtext</key>
+				<string>WARNING: loud, no system volume contorl</string>
+				<key>text</key>
+				<string>Switch audio output to external device</string>
+				<key>withspace</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>728B5A4C-49FB-4657-8E62-EF5B81E0ACCA</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>soundname</key>
+				<string>Funk</string>
+				<key>systemsound</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.playsound</string>
+			<key>uid</key>
+			<string>8DD2D80C-83E0-48CC-AAB1-50C062CAEAEE</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -968,6 +1121,27 @@ $audioswitch_path -s "$query"</string>
 			<string>alfred.workflow.output.notification</string>
 			<key>uid</key>
 			<string>09628237-FC1A-4F03-8A93-0F4788E06FB3</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>lastpathcomponent</key>
+				<false/>
+				<key>onlyshowifquerypopulated</key>
+				<false/>
+				<key>removeextension</key>
+				<false/>
+				<key>text</key>
+				<string>Have you run `brew install switchaudio-osx`?</string>
+				<key>title</key>
+				<string>audioswitch not found</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.notification</string>
+			<key>uid</key>
+			<string>73E94FD2-7DA5-4AFA-9246-144509D75D0A</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -1030,157 +1204,6 @@ print json
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>alignment</key>
-				<integer>0</integer>
-				<key>backgroundcolor</key>
-				<string></string>
-				<key>fadespeed</key>
-				<integer>0</integer>
-				<key>fillmode</key>
-				<integer>0</integer>
-				<key>font</key>
-				<string></string>
-				<key>ignoredynamicplaceholders</key>
-				<false/>
-				<key>largetypetext</key>
-				<string>Path not found</string>
-				<key>textcolor</key>
-				<string></string>
-				<key>wrapat</key>
-				<integer>50</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.output.largetype</string>
-			<key>uid</key>
-			<string>3F26E162-AE62-4CA1-8141-1CF497E4B925</string>
-			<key>version</key>
-			<integer>3</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>conditions</key>
-				<array>
-					<dict>
-						<key>inputstring</key>
-						<string>{var:audioswitch_path}</string>
-						<key>matchcasesensitive</key>
-						<false/>
-						<key>matchmode</key>
-						<integer>0</integer>
-						<key>matchstring</key>
-						<string>nf</string>
-						<key>outputlabel</key>
-						<string>nf</string>
-						<key>uid</key>
-						<string>E39327B0-7BD5-413C-AB58-8C271E056095</string>
-					</dict>
-				</array>
-				<key>elselabel</key>
-				<string></string>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.conditional</string>
-			<key>uid</key>
-			<string>60AE39BC-F324-49E0-A554-2C945CFC8458</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>concurrently</key>
-				<false/>
-				<key>escaping</key>
-				<integer>102</integer>
-				<key>script</key>
-				<string>query=$1
-
-if [ "$query" ]; then
-	SWITCHPATH="$1"
-elif [ -f /usr/lib/switchaudiosource ]; then
-    SWITCHPATH="/usr/lib/switchaudiosource"
-elif [ -f /opt/homebrew/bin/switchaudiosource ]; then
-	SWITCHPATH="/opt/homebrew/bin/switchaudiosource"
-else
-	SWITCHPATH"nf"
-fi
-
-/usr/libexec/PlistBuddy -c "Set :variables:audioswitch_path \"$SWITCHPATH\"" info.plist</string>
-				<key>scriptargtype</key>
-				<integer>1</integer>
-				<key>scriptfile</key>
-				<string></string>
-				<key>type</key>
-				<integer>0</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argumenttype</key>
-				<integer>1</integer>
-				<key>keyword</key>
-				<string>asc</string>
-				<key>subtext</key>
-				<string>If you installed the binary in a custom path, pass it as argument.</string>
-				<key>text</key>
-				<string>Configure autoswitch path</string>
-				<key>withspace</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
-			<key>uid</key>
-			<string>D59239E5-888F-44C4-8C72-49FCF029D846</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>soundname</key>
-				<string>Funk</string>
-				<key>systemsound</key>
-				<true/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.output.playsound</string>
-			<key>uid</key>
-			<string>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>lastpathcomponent</key>
-				<false/>
-				<key>onlyshowifquerypopulated</key>
-				<false/>
-				<key>removeextension</key>
-				<false/>
-				<key>text</key>
-				<string>Configuration completed</string>
-				<key>title</key>
-				<string>Audio Switcher</string>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.output.notification</string>
-			<key>uid</key>
-			<string>18DD4ECD-D3CC-4456-8B95-C6A6E045AC87</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
 	</array>
 	<key>readme</key>
 	<string>Alfred Workflow to switch audio devices.
@@ -1198,30 +1221,23 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 		<key>09628237-FC1A-4F03-8A93-0F4788E06FB3</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1665</integer>
+			<integer>1850</integer>
 			<key>ypos</key>
-			<integer>355</integer>
+			<integer>295</integer>
 		</dict>
 		<key>1495BA6A-8FB6-4DE4-81B5-3CFE151A840E</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1465</integer>
+			<integer>1650</integer>
 			<key>ypos</key>
-			<integer>290</integer>
-		</dict>
-		<key>18DD4ECD-D3CC-4456-8B95-C6A6E045AC87</key>
-		<dict>
-			<key>xpos</key>
-			<integer>815</integer>
-			<key>ypos</key>
-			<integer>610</integer>
+			<integer>230</integer>
 		</dict>
 		<key>1968F288-3B50-4AC0-937E-1D82912AB1B5</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1090</integer>
+			<integer>1275</integer>
 			<key>ypos</key>
-			<integer>105</integer>
+			<integer>50</integer>
 		</dict>
 		<key>197D094B-47AC-495F-9397-41F710D42765</key>
 		<dict>
@@ -1240,16 +1256,9 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 		<key>33383FFA-0734-4D1B-8544-AF2BE673B5E8</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1665</integer>
+			<integer>1850</integer>
 			<key>ypos</key>
-			<integer>235</integer>
-		</dict>
-		<key>3F26E162-AE62-4CA1-8141-1CF497E4B925</key>
-		<dict>
-			<key>xpos</key>
-			<integer>630</integer>
-			<key>ypos</key>
-			<integer>480</integer>
+			<integer>175</integer>
 		</dict>
 		<key>49778D70-5A39-40D0-B412-3AEEFC0FB088</key>
 		<dict>
@@ -1258,35 +1267,35 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>ypos</key>
 			<integer>55</integer>
 		</dict>
-		<key>525F5E84-1DDA-4BC2-AE06-2A007CC60F42</key>
+		<key>4FE1F8FB-702B-4376-97D0-5A156EC1395E</key>
 		<dict>
 			<key>xpos</key>
-			<integer>265</integer>
+			<integer>1330</integer>
 			<key>ypos</key>
-			<integer>550</integer>
+			<integer>225</integer>
 		</dict>
 		<key>548FC2F7-5327-4242-BA1A-CAEBBEB41FF2</key>
 		<dict>
 			<key>xpos</key>
-			<integer>905</integer>
+			<integer>1090</integer>
 			<key>ypos</key>
-			<integer>115</integer>
-		</dict>
-		<key>60AE39BC-F324-49E0-A554-2C945CFC8458</key>
-		<dict>
-			<key>xpos</key>
-			<integer>475</integer>
-			<key>ypos</key>
-			<integer>530</integer>
+			<integer>60</integer>
 		</dict>
 		<key>620BA959-FAC3-4CC8-A160-AA818683968E</key>
 		<dict>
 			<key>note</key>
 			<string>Write changes back to workflow environment variables, can take a few seconds to apply.</string>
 			<key>xpos</key>
-			<integer>1465</integer>
+			<integer>1650</integer>
 			<key>ypos</key>
-			<integer>100</integer>
+			<integer>45</integer>
+		</dict>
+		<key>6BAA32B6-8AB0-4144-85F2-24D886B477D8</key>
+		<dict>
+			<key>xpos</key>
+			<integer>1070</integer>
+			<key>ypos</key>
+			<integer>265</integer>
 		</dict>
 		<key>70E414DC-BC7B-4DC4-8316-E78DE658D2ED</key>
 		<dict>
@@ -1302,12 +1311,26 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>ypos</key>
 			<integer>265</integer>
 		</dict>
+		<key>73E94FD2-7DA5-4AFA-9246-144509D75D0A</key>
+		<dict>
+			<key>xpos</key>
+			<integer>1335</integer>
+			<key>ypos</key>
+			<integer>345</integer>
+		</dict>
 		<key>7D0E02FB-B5A5-458F-AB93-F258E7B30E8B</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1245</integer>
+			<integer>1430</integer>
 			<key>ypos</key>
-			<integer>75</integer>
+			<integer>20</integer>
+		</dict>
+		<key>8DD2D80C-83E0-48CC-AAB1-50C062CAEAEE</key>
+		<dict>
+			<key>xpos</key>
+			<integer>1485</integer>
+			<key>ypos</key>
+			<integer>290</integer>
 		</dict>
 		<key>AE8B0F21-A389-4316-8E23-D5647A36D2B2</key>
 		<dict>
@@ -1319,9 +1342,9 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 		<key>B7FE4BF5-5800-4C0B-A6A0-B50CF0203BFF</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1365</integer>
+			<integer>1550</integer>
 			<key>ypos</key>
-			<integer>130</integer>
+			<integer>75</integer>
 		</dict>
 		<key>BEB65075-1263-4D24-808C-B6B29E5C3C15</key>
 		<dict>
@@ -1329,6 +1352,13 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<integer>565</integer>
 			<key>ypos</key>
 			<integer>100</integer>
+		</dict>
+		<key>C53A449E-1DA9-4409-80E7-5B0DF8412174</key>
+		<dict>
+			<key>xpos</key>
+			<integer>895</integer>
+			<key>ypos</key>
+			<integer>245</integer>
 		</dict>
 		<key>C8A8002F-B413-4509-B43A-9E7776401A27</key>
 		<dict>
@@ -1351,40 +1381,33 @@ Requires switchaudiosource to be installed with `brew install switchaudio-osx`</
 			<key>ypos</key>
 			<integer>160</integer>
 		</dict>
-		<key>D59239E5-888F-44C4-8C72-49FCF029D846</key>
+		<key>D5E09E98-C428-4634-AC59-E74EDF974AD0</key>
 		<dict>
 			<key>xpos</key>
-			<integer>30</integer>
+			<integer>685</integer>
 			<key>ypos</key>
-			<integer>550</integer>
+			<integer>150</integer>
 		</dict>
 		<key>D6209BF9-6CC3-41A8-8479-11F28E98278B</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1245</integer>
+			<integer>1430</integer>
 			<key>ypos</key>
-			<integer>130</integer>
+			<integer>75</integer>
 		</dict>
 		<key>D948D25C-D746-40A9-9BB0-DFF412AE65F1</key>
 		<dict>
 			<key>xpos</key>
-			<integer>1245</integer>
+			<integer>1430</integer>
 			<key>ypos</key>
-			<integer>190</integer>
+			<integer>135</integer>
 		</dict>
 		<key>DC5AEE40-4C20-47A1-9B39-972783E5FDE4</key>
 		<dict>
 			<key>xpos</key>
-			<integer>710</integer>
+			<integer>895</integer>
 			<key>ypos</key>
-			<integer>150</integer>
-		</dict>
-		<key>E6E9F145-B25A-456D-8B5B-82EA3E62EC13</key>
-		<dict>
-			<key>xpos</key>
-			<integer>635</integer>
-			<key>ypos</key>
-			<integer>610</integer>
+			<integer>95</integer>
 		</dict>
 	</dict>
 	<key>variables</key>


### PR DESCRIPTION
Co-authored by @Jeffr89

Auto-detection of `switchaudiosource` path.

When first invoking, it will try to find the `switchaudiosource` path and store it. If it can't find it, it should raise an alert. Otherwise, on the next invocation, it should present a list of audio sources for the selected device, and save that selection for next time.

Opening a new PR, as I couldn't work out how to contribute my changes back to #2.